### PR TITLE
Some export functionality for RIS file dumps.

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,7 @@
 - Model Selection
-- add Author / Verlag feature
+- more features:
+    - add Author / Verlag feature
+    - Journal (JA)
 - 4 augen prinzip GUI
 - label imbalance / thresholding 
 - label imbalance / resampling / reweight

--- a/django/dkg/cancer/ris.py
+++ b/django/dkg/cancer/ris.py
@@ -2,6 +2,7 @@ import re
 
 RISSTART = '\r'
 
+
 def read_article(lines):
     '''
     Reads single RIS tag
@@ -15,6 +16,7 @@ def read_article(lines):
             if key in article: article[key] += [value]
             else: article[key] = [value]
     return article
+
 
 def read_ris_lines(lines):
     '''
@@ -30,29 +32,30 @@ def read_ris_lines(lines):
     articles = [read_article(lines[startArticle[s]:startArticle[s+1]]) for s in range(len(startArticle)-1)]
     return pd.DataFrame(articles)
 
+
 def write_article(article):
-    '''
+    """
     Writes single article to RIS string
     the column 'keywords' is assumed to contain the assigned keywords as tuples
     ('label','score','anotator')
     TODO: better keyword-list flattening, currently only labels are extracted
             problem is that there is only the KW RIS tag,
             we'd need annotator/score specific RIS tags
-    '''
+    """
     ris = []
-    for k,v in article.items():
-        if k == 'keywords':
+    for k,v in article.iteritems():
+        if k == 'KW':
             for kw in v:
                 ris.append("KW  - " + kw[0])
         else:
-            ris.append(k + "  - " + v)
+            ris.append(str(k) + "  - " + str(v))
     return "\n".join(ris)
 
-def write_ris_lines(fn, df):
-    '''
-    Writes a pandas dataframe to RIS file.
 
-    '''
+def write_ris_lines(fn, df):
+    """
+    Writes a pandas dataframe to RIS file.
+    """
     with open(fn, 'w') as fh:
         for _, article in df.iterrows():
             fh.write(write_article(article) + "\n\n")

--- a/django/dkg/cancer/ris.py
+++ b/django/dkg/cancer/ris.py
@@ -3,6 +3,9 @@ import re
 RISSTART = '\r'
 
 def read_article(lines):
+    '''
+    Reads single RIS tag
+    '''
     article = {}
     for line in lines:
         match = re.match("[A-Z0-9]{2}\s+-",line)
@@ -14,7 +17,42 @@ def read_article(lines):
     return article
 
 def read_ris_lines(lines):
+    '''
+    RIS file import
+    INPUT:
+    lines   lines of RIS file
+    OUTPUT:
+    pandas dataframe, columns corresponding to RIS tags
+    '''
+
     import pandas as pd
     startArticle = [idx for idx,l in enumerate(lines) if re.match(RISSTART, l)]
     articles = [read_article(lines[startArticle[s]:startArticle[s+1]]) for s in range(len(startArticle)-1)]
     return pd.DataFrame(articles)
+
+def write_article(article):
+    '''
+    Writes single article to RIS string
+    the column 'keywords' is assumed to contain the assigned keywords as tuples
+    ('label','score','anotator')
+    TODO: better keyword-list flattening, currently only labels are extracted
+            problem is that there is only the KW RIS tag,
+            we'd need annotator/score specific RIS tags
+    '''
+    ris = []
+    for k,v in article.items():
+        if k == 'keywords':
+            for kw in v:
+                ris.append("KW  - " + kw[0])
+        else:
+            ris.append(k + "  - " + v)
+    return "\n".join(ris)
+
+def write_ris_lines(fn, df):
+    '''
+    Writes a pandas dataframe to RIS file.
+
+    '''
+    with open(fn, 'w') as fh:
+        for _, article in df.iterrows():
+            fh.write(write_article(article) + "\n\n")

--- a/django/dkg/cancer/templates/cancer/bs.html
+++ b/django/dkg/cancer/templates/cancer/bs.html
@@ -117,6 +117,12 @@
             <form action="/cancer/" , method=post enctype=multipart/form-data>
                 <input type=file name=file><input type=submit name=test value=test>
             </form>
+            <h3>
+                Download reviewed Test RIS File
+            </h3>
+            <form action="/cancer/download_test_ris" , method=post enctype=multipart/form-data>
+                <input type=submit name=download value=download>
+            </form>
         </div>
         <div class="col-md-10">
             <h2>

--- a/django/dkg/cancer/urls.py
+++ b/django/dkg/cancer/urls.py
@@ -10,4 +10,6 @@ urlpatterns = [
     url(r'json/train', json_api.train, name='train'),
     url(r'json/inference', json_api.inference, name='inference'),
     url(r'json/feedback', json_api.feedback, name='feedback'),
+
+    url(r'download_test_ris', views.download_test_ris, name='download_test_ris'),
 ]

--- a/django/dkg/dkg/settings.py
+++ b/django/dkg/dkg/settings.py
@@ -127,6 +127,7 @@ LABEL_CODES_PATH = '/tmp/label_codes.pkl'
 
 TRAIN_ARTICLES_PATH = '/tmp/train.pkl'
 INFERENCE_ARTICLES_PATH = '/tmp/inference.pkl'
+INFERENCE_ARTICLES_RIS_PATH = '/tmp/inference.ris'
 
 # only show labels with a probability >= than this value
 INFERENCE_LABEL_THRESHOLD = 0.5


### PR DESCRIPTION
Assumes current Tuple format and column name 'keywords' for predicted kws
Annotator name and score are discarded in RIS export.
TODO: Change in inference article format, so that we drag all original RIS tags all the way to the RIS export after inference. 