### PR TITLE
feature encoder now as pipeline with itemselector and featureunion

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -4,7 +4,6 @@
 - active learning offline evaluierung
 - training/test data versioning
 - keep history of training/test data
-- use pipelines for training, persist and reuse for test (FeatureUnion with ItemSelector)
 
 - async:
     - websockets for async communication

--- a/django/dkg/cancer/json_api/endpoints.py
+++ b/django/dkg/cancer/json_api/endpoints.py
@@ -51,7 +51,8 @@ def train(request):
     cancer.model_api.model.train_model(
         articles_with_keywords_and_probas,
         django.conf.settings.MODEL_PATH,
-        django.conf.settings.LABEL_CODES_PATH
+        django.conf.settings.LABEL_CODES_PATH,
+        django.conf.settings.FEATURE_ENCODER_PATH
     )
 
     return HttpResponse(status=200)
@@ -95,7 +96,8 @@ def inference(request):
     label_probas, labels_binarized, label_names = cancer.model_api.model.inference_with_model(
         articles,
         django.conf.settings.MODEL_PATH,
-        django.conf.settings.LABEL_CODES_PATH
+        django.conf.settings.LABEL_CODES_PATH,
+        django.conf.settings.FEATURE_ENCODER_PATH
     )
 
     # threshold predicted labels
@@ -164,7 +166,8 @@ def update_model(request):
     cancer.model_api.model.train_model(
         merged,
         django.conf.settings.MODEL_PATH,
-        django.conf.settings.LABEL_CODES_PATH
+        django.conf.settings.LABEL_CODES_PATH,
+        django.conf.settings.FEATURE_ENCODER_PATH
     )
 
     return HttpResponse(status=200)

--- a/django/dkg/cancer/model_api/pipelining.py
+++ b/django/dkg/cancer/model_api/pipelining.py
@@ -1,0 +1,41 @@
+from sklearn.base import BaseEstimator, TransformerMixin
+
+
+class ItemSelector(BaseEstimator, TransformerMixin):
+    """For data grouped by feature, select subset of data at a provided key.
+
+    The data is expected to be stored in a 2D data structure, where the first
+    index is over features and the second is over samples.  i.e.
+
+    >> len(data[key]) == n_samples
+
+    Please note that this is the opposite convention to scikit-learn feature
+    matrixes (where the first index corresponds to sample).
+
+    ItemSelector only requires that the collection implement getitem
+    (data[key]).  Examples include: a dict of lists, 2D numpy array, Pandas
+    DataFrame, numpy record array, etc.
+
+    >> data = {'a': [1, 5, 2, 5, 2, 8],
+               'b': [9, 4, 1, 4, 1, 3]}
+    >> ds = ItemSelector(key='a')
+    >> data['a'] == ds.transform(data)
+
+    ItemSelector is not designed to handle data grouped by sample.  (e.g. a
+    list of dicts).  If your data is structured this way, consider a
+    transformer along the lines of `sklearn.feature_extraction.DictVectorizer`.
+
+    Parameters
+    ----------
+    key : hashable, required
+        The key corresponding to the desired value in a mappable.
+    """
+    def __init__(self, key):
+        self.key = key
+
+    def fit(self, x, y=None):
+        return self
+
+    def transform(self, data_dict):
+        return data_dict[self.key]
+

--- a/django/dkg/dkg/settings.py
+++ b/django/dkg/dkg/settings.py
@@ -137,7 +137,10 @@ INFERENCE_ARTICLES_RIS_PATH = '/tmp/inference.ris'
 INFERENCE_LABEL_THRESHOLD = 0.5
 
 # file to store number of feedbacks to inference articles into
-FEEDBACK_COUNTER_PATH = '/tmp/feedback_count'
+# FEEDBACK_COUNTER_PATH = '/tmp/feedback_count'
+
+# encoder sklearn Pipeline save path
+FEATURE_ENCODER_PATH = '/tmp/feature_encoder_pipeline.pkl'
 
 # label pruning normalized value counts threshold
 LABEL_PRUNING_VALUE_COUNTS_THRESHOLD = 0.66


### PR DESCRIPTION
can now use feature transformers that actually depend on the data (e.g. LabelBinarizer etc.).

the training encoder pipeline is saved to disk and loaded for encoding the test articles.